### PR TITLE
fix: :bug: Limit the push trigger to main.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,6 +2,8 @@ name: Continuous Integration / Continuous Delivery Workflow for the Parameter Pa
 
 on:
   push:
+    branches:
+      - "main"
 
   pull_request:
     branches:


### PR DESCRIPTION
The action was triggering twice for PRs to main. This limts that to run only on push to main. I'm not sure if it will re-run from a PR on merge.