### PR TITLE
feat: :sparkles: Make the app text selectable.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ class FermiApp extends StatelessWidget {
       theme: GlobalAppTheme.lightTheme,
       darkTheme: GlobalAppTheme.darkTheme,
       themeMode: ThemeMode.system,
-      home: child,
+      home: SelectionArea(child: child),
     );
   }
 }


### PR DESCRIPTION
Wrap the App home child in a SelectionArea widget to make the application text selectable aligning with functionality of the existing system and browser applications.

Closes #10.