### PR TITLE
Fixed issue with Chrome.

### DIFF
--- a/lib/gql-dpm/graphql_dpm_service.dart
+++ b/lib/gql-dpm/graphql_dpm_service.dart
@@ -30,7 +30,7 @@ class GraphQLDpmService extends DpmService {
             Uri(
               scheme: "http",
               host: "127.0.0.1",
-              port: 8000,
+              port: 8080,
               path: "/dpm/q",
             ).toString(),
           ),
@@ -38,14 +38,16 @@ class GraphQLDpmService extends DpmService {
         ),
         _s = Client(
           link: WebSocketLink(
-            Uri(
-              scheme: "ws",
-              host: "127.0.0.1",
-              port: 8000,
-              path: "/dpm/s",
-            ).toString(),
-            reconnectInterval: const Duration(seconds: 1),
-          ),
+              Uri(
+                scheme: "ws",
+                host: "127.0.0.1",
+                port: 8080,
+                path: "/dpm/s",
+              ).toString(),
+              reconnectInterval: const Duration(seconds: 1),
+              initialPayload: {
+                "headers": {"sec-websocket-protocol": "graphql-ws"}
+              }),
           cache: Cache(),
         );
 


### PR DESCRIPTION
GraphQL subscriptions weren't working on Chrome browsers. Beau and I found out our GraphQL library didn't specify the `sec-websocket-protocol` header when upgrading to a websocket and our service was always returning it. Chrome doesn't like that.

Beaus found a way to add this header to our request, which is the content of this commit.