### PR TITLE
ci: Upgrade to cache v3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /opt/hostedtoolcache/flutter
           key: flutter-install-cache
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /opt/hostedtoolcache/flutter
           key: flutter-install-cache
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /opt/hostedtoolcache/flutter
           key: flutter-install-cache


### PR DESCRIPTION
The cache v3 updated the minimum runner version support from node 12 -> node 16.