### PR TITLE
Fix `deviceInfo` query

### DIFF
--- a/lib/dpm_service.dart
+++ b/lib/dpm_service.dart
@@ -28,8 +28,8 @@ class DPMGraphQLException extends DPMException {
 // much, if at all.
 
 class DeviceInfoProperty {
-  final String commonUnits;
-  final String primaryUnits;
+  final String? commonUnits;
+  final String? primaryUnits;
 
   const DeviceInfoProperty(
       {required this.commonUnits, required this.primaryUnits});

--- a/lib/gql-dpm/graphql_dpm_service.dart
+++ b/lib/gql-dpm/graphql_dpm_service.dart
@@ -94,7 +94,7 @@ class GraphQLDpmService extends DpmService {
             // Iterate across the list to generate a new one with our "nicer"
             // class type.
 
-            return response.data!.acceleratorData
+            return response.data!.deviceInfo.result
                 .map(_convertToDevInfo)
                 .toList();
           } else {
@@ -113,17 +113,36 @@ class GraphQLDpmService extends DpmService {
   // Private conversion method to convert an obnoxiously named, nested class
   // into our nicer, flatter one. Used by `getDeviceInfo()`.
 
-  static DeviceInfo _convertToDevInfo(GGetDeviceInfoData_acceleratorData e) =>
-      DeviceInfo(
-          di: e.data.di,
-          name: e.data.name,
-          description: e.data.description,
-          reading: DeviceInfoProperty(
-              commonUnits: e.data.units ?? "",
-              primaryUnits: e.data.units ?? ""),
-          setting: DeviceInfoProperty(
-              commonUnits: e.data.units ?? "",
-              primaryUnits: e.data.units ?? ""));
+  static DeviceInfo _convertToDevInfo(GGetDeviceInfoData_deviceInfo_result e) {
+    if (e is GGetDeviceInfoData_deviceInfo_result__asDeviceInfo) {
+      final DeviceInfoProperty? rProp = e.reading != null
+          ? DeviceInfoProperty(
+              primaryUnits: e.reading!.primaryUnits,
+              commonUnits: e.reading!.commonUnits)
+          : null;
+      final DeviceInfoProperty? sProp = e.reading != null
+          ? DeviceInfoProperty(
+              primaryUnits: e.reading!.primaryUnits,
+              commonUnits: e.reading!.commonUnits)
+          : null;
+
+      return DeviceInfo(
+        di: 0,
+        name: "",
+        description: e.description,
+        reading: rProp,
+        setting: sProp,
+      );
+    } else {
+      return const DeviceInfo(
+        di: 0,
+        name: "",
+        description: "",
+        reading: null,
+        setting: null,
+      );
+    }
+  }
 
   // Returns a stream of readings for the devices specified in the parameter
   // list. The `Reading` class has a `refId` field which indicates to which

--- a/lib/gql-dpm/schema/DPM.graphql
+++ b/lib/gql-dpm/schema/DPM.graphql
@@ -53,8 +53,32 @@ type DataReply {
     data: DataInfo!
 }
 
+type DeviceProperty {
+    primaryUnits: String
+    commonUnits: String
+}
+
+type DeviceInfo {
+    description: String!
+    reading: DeviceProperty
+    setting: DeviceProperty
+}
+
+type ErrorReply {
+    message: String!
+}
+
+union DeviceInfoResult =
+      DeviceInfo
+    | ErrorReply
+
+type DeviceInfoReply {
+    result: [DeviceInfoResult!]!
+}
+
 type Query {
     acceleratorData(drfs: [String!]!): [DataReply!]!
+    deviceInfo(device: [String!]!): DeviceInfoReply!
 }
 
 type Subscription {

--- a/lib/gql-dpm/schema/__generated__/DPM.ast.gql.dart
+++ b/lib/gql-dpm/schema/__generated__/DPM.ast.gql.dart
@@ -264,6 +264,114 @@ const DataReply = _i1.ObjectTypeDefinitionNode(
     ),
   ],
 );
+const DeviceProperty = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'DeviceProperty'),
+  directives: [],
+  interfaces: [],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'primaryUnits'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: false,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'commonUnits'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: false,
+      ),
+    ),
+  ],
+);
+const DeviceInfo = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'DeviceInfo'),
+  directives: [],
+  interfaces: [],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'description'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'reading'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'DeviceProperty'),
+        isNonNull: false,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'setting'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'DeviceProperty'),
+        isNonNull: false,
+      ),
+    ),
+  ],
+);
+const ErrorReply = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'ErrorReply'),
+  directives: [],
+  interfaces: [],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'message'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    )
+  ],
+);
+const DeviceInfoResult = _i1.UnionTypeDefinitionNode(
+  name: _i1.NameNode(value: 'DeviceInfoResult'),
+  directives: [],
+  types: [
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'DeviceInfo'),
+      isNonNull: false,
+    ),
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'ErrorReply'),
+      isNonNull: false,
+    ),
+  ],
+);
+const DeviceInfoReply = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'DeviceInfoReply'),
+  directives: [],
+  interfaces: [],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'result'),
+      directives: [],
+      args: [],
+      type: _i1.ListTypeNode(
+        type: _i1.NamedTypeNode(
+          name: _i1.NameNode(value: 'DeviceInfoResult'),
+          isNonNull: true,
+        ),
+        isNonNull: true,
+      ),
+    )
+  ],
+);
 const Query = _i1.ObjectTypeDefinitionNode(
   name: _i1.NameNode(value: 'Query'),
   directives: [],
@@ -293,7 +401,29 @@ const Query = _i1.ObjectTypeDefinitionNode(
         ),
         isNonNull: true,
       ),
-    )
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'deviceInfo'),
+      directives: [],
+      args: [
+        _i1.InputValueDefinitionNode(
+          name: _i1.NameNode(value: 'device'),
+          directives: [],
+          type: _i1.ListTypeNode(
+            type: _i1.NamedTypeNode(
+              name: _i1.NameNode(value: 'String'),
+              isNonNull: true,
+            ),
+            isNonNull: true,
+          ),
+          defaultValue: null,
+        )
+      ],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'DeviceInfoReply'),
+        isNonNull: true,
+      ),
+    ),
   ],
 );
 const Subscription = _i1.ObjectTypeDefinitionNode(
@@ -337,6 +467,11 @@ const document = _i1.DocumentNode(definitions: [
   StructData,
   DataInfo,
   DataReply,
+  DeviceProperty,
+  DeviceInfo,
+  ErrorReply,
+  DeviceInfoResult,
+  DeviceInfoReply,
   Query,
   Subscription,
 ]);

--- a/lib/gql-dpm/schema/__generated__/get_device_info.ast.gql.dart
+++ b/lib/gql-dpm/schema/__generated__/get_device_info.ast.gql.dart
@@ -24,59 +24,102 @@ const GetDeviceInfo = _i1.OperationDefinitionNode(
   directives: [],
   selectionSet: _i1.SelectionSetNode(selections: [
     _i1.FieldNode(
-      name: _i1.NameNode(value: 'acceleratorData'),
+      name: _i1.NameNode(value: 'deviceInfo'),
       alias: null,
       arguments: [
         _i1.ArgumentNode(
-          name: _i1.NameNode(value: 'drfs'),
+          name: _i1.NameNode(value: 'devices'),
           value: _i1.VariableNode(name: _i1.NameNode(value: 'names')),
         )
       ],
       directives: [],
       selectionSet: _i1.SelectionSetNode(selections: [
         _i1.FieldNode(
-          name: _i1.NameNode(value: 'refId'),
-          alias: null,
-          arguments: [],
-          directives: [],
-          selectionSet: null,
-        ),
-        _i1.FieldNode(
-          name: _i1.NameNode(value: 'data'),
+          name: _i1.NameNode(value: 'result'),
           alias: null,
           arguments: [],
           directives: [],
           selectionSet: _i1.SelectionSetNode(selections: [
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'di'),
-              alias: null,
-              arguments: [],
+            _i1.InlineFragmentNode(
+              typeCondition: _i1.TypeConditionNode(
+                  on: _i1.NamedTypeNode(
+                name: _i1.NameNode(value: 'DeviceInfo'),
+                isNonNull: false,
+              )),
               directives: [],
-              selectionSet: null,
+              selectionSet: _i1.SelectionSetNode(selections: [
+                _i1.FieldNode(
+                  name: _i1.NameNode(value: 'description'),
+                  alias: null,
+                  arguments: [],
+                  directives: [],
+                  selectionSet: null,
+                ),
+                _i1.FieldNode(
+                  name: _i1.NameNode(value: 'reading'),
+                  alias: null,
+                  arguments: [],
+                  directives: [],
+                  selectionSet: _i1.SelectionSetNode(selections: [
+                    _i1.FieldNode(
+                      name: _i1.NameNode(value: 'primaryUnits'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null,
+                    ),
+                    _i1.FieldNode(
+                      name: _i1.NameNode(value: 'commonUnits'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null,
+                    ),
+                  ]),
+                ),
+                _i1.FieldNode(
+                  name: _i1.NameNode(value: 'setting'),
+                  alias: null,
+                  arguments: [],
+                  directives: [],
+                  selectionSet: _i1.SelectionSetNode(selections: [
+                    _i1.FieldNode(
+                      name: _i1.NameNode(value: 'primaryUnits'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null,
+                    ),
+                    _i1.FieldNode(
+                      name: _i1.NameNode(value: 'commonUnits'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null,
+                    ),
+                  ]),
+                ),
+              ]),
             ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'name'),
-              alias: null,
-              arguments: [],
+            _i1.InlineFragmentNode(
+              typeCondition: _i1.TypeConditionNode(
+                  on: _i1.NamedTypeNode(
+                name: _i1.NameNode(value: 'ErrorReply'),
+                isNonNull: false,
+              )),
               directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'description'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'units'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
+              selectionSet: _i1.SelectionSetNode(selections: [
+                _i1.FieldNode(
+                  name: _i1.NameNode(value: 'message'),
+                  alias: null,
+                  arguments: [],
+                  directives: [],
+                  selectionSet: null,
+                )
+              ]),
             ),
           ]),
-        ),
+        )
       ]),
     )
   ]),

--- a/lib/gql-dpm/schema/__generated__/get_device_info.data.gql.dart
+++ b/lib/gql-dpm/schema/__generated__/get_device_info.data.gql.dart
@@ -5,6 +5,8 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
+import 'package:gql_code_builder/src/serializers/inline_fragment_serializer.dart'
+    as _i2;
 import 'package:parameter_page/gql-dpm/schema/__generated__/serializers.gql.dart'
     as _i1;
 
@@ -21,7 +23,7 @@ abstract class GGetDeviceInfoData
       b..G__typename = 'Query';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  BuiltList<GGetDeviceInfoData_acceleratorData> get acceleratorData;
+  GGetDeviceInfoData_deviceInfo get deviceInfo;
   static Serializer<GGetDeviceInfoData> get serializer =>
       _$gGetDeviceInfoDataSerializer;
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
@@ -35,65 +37,226 @@ abstract class GGetDeviceInfoData
       );
 }
 
-abstract class GGetDeviceInfoData_acceleratorData
+abstract class GGetDeviceInfoData_deviceInfo
     implements
-        Built<GGetDeviceInfoData_acceleratorData,
-            GGetDeviceInfoData_acceleratorDataBuilder> {
-  GGetDeviceInfoData_acceleratorData._();
+        Built<GGetDeviceInfoData_deviceInfo,
+            GGetDeviceInfoData_deviceInfoBuilder> {
+  GGetDeviceInfoData_deviceInfo._();
 
-  factory GGetDeviceInfoData_acceleratorData(
-          [Function(GGetDeviceInfoData_acceleratorDataBuilder b) updates]) =
-      _$GGetDeviceInfoData_acceleratorData;
+  factory GGetDeviceInfoData_deviceInfo(
+          [Function(GGetDeviceInfoData_deviceInfoBuilder b) updates]) =
+      _$GGetDeviceInfoData_deviceInfo;
 
-  static void _initializeBuilder(GGetDeviceInfoData_acceleratorDataBuilder b) =>
-      b..G__typename = 'DataReply';
+  static void _initializeBuilder(GGetDeviceInfoData_deviceInfoBuilder b) =>
+      b..G__typename = 'DeviceInfoReply';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  int get refId;
-  GGetDeviceInfoData_acceleratorData_data get data;
-  static Serializer<GGetDeviceInfoData_acceleratorData> get serializer =>
-      _$gGetDeviceInfoDataAcceleratorDataSerializer;
+  BuiltList<GGetDeviceInfoData_deviceInfo_result> get result;
+  static Serializer<GGetDeviceInfoData_deviceInfo> get serializer =>
+      _$gGetDeviceInfoDataDeviceInfoSerializer;
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GGetDeviceInfoData_acceleratorData.serializer,
+        GGetDeviceInfoData_deviceInfo.serializer,
         this,
       ) as Map<String, dynamic>);
-  static GGetDeviceInfoData_acceleratorData? fromJson(
-          Map<String, dynamic> json) =>
+  static GGetDeviceInfoData_deviceInfo? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
-        GGetDeviceInfoData_acceleratorData.serializer,
+        GGetDeviceInfoData_deviceInfo.serializer,
         json,
       );
 }
 
-abstract class GGetDeviceInfoData_acceleratorData_data
-    implements
-        Built<GGetDeviceInfoData_acceleratorData_data,
-            GGetDeviceInfoData_acceleratorData_dataBuilder> {
-  GGetDeviceInfoData_acceleratorData_data._();
-
-  factory GGetDeviceInfoData_acceleratorData_data(
-      [Function(GGetDeviceInfoData_acceleratorData_dataBuilder b)
-          updates]) = _$GGetDeviceInfoData_acceleratorData_data;
-
-  static void _initializeBuilder(
-          GGetDeviceInfoData_acceleratorData_dataBuilder b) =>
-      b..G__typename = 'DataInfo';
+abstract class GGetDeviceInfoData_deviceInfo_result {
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  int get di;
-  String get name;
-  String get description;
-  String? get units;
-  static Serializer<GGetDeviceInfoData_acceleratorData_data> get serializer =>
-      _$gGetDeviceInfoDataAcceleratorDataDataSerializer;
+  static Serializer<GGetDeviceInfoData_deviceInfo_result> get serializer =>
+      _i2.InlineFragmentSerializer<GGetDeviceInfoData_deviceInfo_result>(
+        'GGetDeviceInfoData_deviceInfo_result',
+        GGetDeviceInfoData_deviceInfo_result__base,
+        {
+          'DeviceInfo': GGetDeviceInfoData_deviceInfo_result__asDeviceInfo,
+          'ErrorReply': GGetDeviceInfoData_deviceInfo_result__asErrorReply,
+        },
+      );
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GGetDeviceInfoData_acceleratorData_data.serializer,
+        GGetDeviceInfoData_deviceInfo_result.serializer,
         this,
       ) as Map<String, dynamic>);
-  static GGetDeviceInfoData_acceleratorData_data? fromJson(
+  static GGetDeviceInfoData_deviceInfo_result? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
-        GGetDeviceInfoData_acceleratorData_data.serializer,
+        GGetDeviceInfoData_deviceInfo_result.serializer,
+        json,
+      );
+}
+
+abstract class GGetDeviceInfoData_deviceInfo_result__base
+    implements
+        Built<GGetDeviceInfoData_deviceInfo_result__base,
+            GGetDeviceInfoData_deviceInfo_result__baseBuilder>,
+        GGetDeviceInfoData_deviceInfo_result {
+  GGetDeviceInfoData_deviceInfo_result__base._();
+
+  factory GGetDeviceInfoData_deviceInfo_result__base(
+      [Function(GGetDeviceInfoData_deviceInfo_result__baseBuilder b)
+          updates]) = _$GGetDeviceInfoData_deviceInfo_result__base;
+
+  static void _initializeBuilder(
+          GGetDeviceInfoData_deviceInfo_result__baseBuilder b) =>
+      b..G__typename = 'DeviceInfoResult';
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  static Serializer<GGetDeviceInfoData_deviceInfo_result__base>
+      get serializer => _$gGetDeviceInfoDataDeviceInfoResultBaseSerializer;
+  @override
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetDeviceInfoData_deviceInfo_result__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+  static GGetDeviceInfoData_deviceInfo_result__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetDeviceInfoData_deviceInfo_result__base.serializer,
+        json,
+      );
+}
+
+abstract class GGetDeviceInfoData_deviceInfo_result__asDeviceInfo
+    implements
+        Built<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo,
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder>,
+        GGetDeviceInfoData_deviceInfo_result {
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo._();
+
+  factory GGetDeviceInfoData_deviceInfo_result__asDeviceInfo(
+      [Function(GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder b)
+          updates]) = _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo;
+
+  static void _initializeBuilder(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder b) =>
+      b..G__typename = 'DeviceInfo';
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  String get description;
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading? get reading;
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting? get setting;
+  static Serializer<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo>
+      get serializer =>
+          _$gGetDeviceInfoDataDeviceInfoResultAsDeviceInfoSerializer;
+  @override
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo.serializer,
+        this,
+      ) as Map<String, dynamic>);
+  static GGetDeviceInfoData_deviceInfo_result__asDeviceInfo? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo.serializer,
+        json,
+      );
+}
+
+abstract class GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading
+    implements
+        Built<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading,
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder> {
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading._();
+
+  factory GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading(
+      [Function(
+              GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder
+                  b)
+          updates]) = _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading;
+
+  static void _initializeBuilder(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder
+              b) =>
+      b..G__typename = 'DeviceProperty';
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  String? get primaryUnits;
+  String? get commonUnits;
+  static Serializer<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading>
+      get serializer =>
+          _$gGetDeviceInfoDataDeviceInfoResultAsDeviceInfoReadingSerializer;
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading.serializer,
+        this,
+      ) as Map<String, dynamic>);
+  static GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading.serializer,
+        json,
+      );
+}
+
+abstract class GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting
+    implements
+        Built<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting,
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder> {
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting._();
+
+  factory GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting(
+      [Function(
+              GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder
+                  b)
+          updates]) = _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting;
+
+  static void _initializeBuilder(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder
+              b) =>
+      b..G__typename = 'DeviceProperty';
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  String? get primaryUnits;
+  String? get commonUnits;
+  static Serializer<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting>
+      get serializer =>
+          _$gGetDeviceInfoDataDeviceInfoResultAsDeviceInfoSettingSerializer;
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting.serializer,
+        this,
+      ) as Map<String, dynamic>);
+  static GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting.serializer,
+        json,
+      );
+}
+
+abstract class GGetDeviceInfoData_deviceInfo_result__asErrorReply
+    implements
+        Built<GGetDeviceInfoData_deviceInfo_result__asErrorReply,
+            GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder>,
+        GGetDeviceInfoData_deviceInfo_result {
+  GGetDeviceInfoData_deviceInfo_result__asErrorReply._();
+
+  factory GGetDeviceInfoData_deviceInfo_result__asErrorReply(
+      [Function(GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder b)
+          updates]) = _$GGetDeviceInfoData_deviceInfo_result__asErrorReply;
+
+  static void _initializeBuilder(
+          GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder b) =>
+      b..G__typename = 'ErrorReply';
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  String get message;
+  static Serializer<GGetDeviceInfoData_deviceInfo_result__asErrorReply>
+      get serializer =>
+          _$gGetDeviceInfoDataDeviceInfoResultAsErrorReplySerializer;
+  @override
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asErrorReply.serializer,
+        this,
+      ) as Map<String, dynamic>);
+  static GGetDeviceInfoData_deviceInfo_result__asErrorReply? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetDeviceInfoData_deviceInfo_result__asErrorReply.serializer,
         json,
       );
 }

--- a/lib/gql-dpm/schema/__generated__/get_device_info.data.gql.g.dart
+++ b/lib/gql-dpm/schema/__generated__/get_device_info.data.gql.g.dart
@@ -8,12 +8,24 @@ part of 'get_device_info.data.gql.dart';
 
 Serializer<GGetDeviceInfoData> _$gGetDeviceInfoDataSerializer =
     new _$GGetDeviceInfoDataSerializer();
-Serializer<GGetDeviceInfoData_acceleratorData>
-    _$gGetDeviceInfoDataAcceleratorDataSerializer =
-    new _$GGetDeviceInfoData_acceleratorDataSerializer();
-Serializer<GGetDeviceInfoData_acceleratorData_data>
-    _$gGetDeviceInfoDataAcceleratorDataDataSerializer =
-    new _$GGetDeviceInfoData_acceleratorData_dataSerializer();
+Serializer<GGetDeviceInfoData_deviceInfo>
+    _$gGetDeviceInfoDataDeviceInfoSerializer =
+    new _$GGetDeviceInfoData_deviceInfoSerializer();
+Serializer<GGetDeviceInfoData_deviceInfo_result__base>
+    _$gGetDeviceInfoDataDeviceInfoResultBaseSerializer =
+    new _$GGetDeviceInfoData_deviceInfo_result__baseSerializer();
+Serializer<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo>
+    _$gGetDeviceInfoDataDeviceInfoResultAsDeviceInfoSerializer =
+    new _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfoSerializer();
+Serializer<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading>
+    _$gGetDeviceInfoDataDeviceInfoResultAsDeviceInfoReadingSerializer =
+    new _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingSerializer();
+Serializer<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting>
+    _$gGetDeviceInfoDataDeviceInfoResultAsDeviceInfoSettingSerializer =
+    new _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingSerializer();
+Serializer<GGetDeviceInfoData_deviceInfo_result__asErrorReply>
+    _$gGetDeviceInfoDataDeviceInfoResultAsErrorReplySerializer =
+    new _$GGetDeviceInfoData_deviceInfo_result__asErrorReplySerializer();
 
 class _$GGetDeviceInfoDataSerializer
     implements StructuredSerializer<GGetDeviceInfoData> {
@@ -30,10 +42,9 @@ class _$GGetDeviceInfoDataSerializer
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
-      'acceleratorData',
-      serializers.serialize(object.acceleratorData,
-          specifiedType: const FullType(BuiltList,
-              const [const FullType(GGetDeviceInfoData_acceleratorData)])),
+      'deviceInfo',
+      serializers.serialize(object.deviceInfo,
+          specifiedType: const FullType(GGetDeviceInfoData_deviceInfo)),
     ];
 
     return result;
@@ -55,10 +66,65 @@ class _$GGetDeviceInfoDataSerializer
           result.G__typename = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
-        case 'acceleratorData':
-          result.acceleratorData.replace(serializers.deserialize(value,
+        case 'deviceInfo':
+          result.deviceInfo.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GGetDeviceInfoData_deviceInfo))!
+              as GGetDeviceInfoData_deviceInfo);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfoSerializer
+    implements StructuredSerializer<GGetDeviceInfoData_deviceInfo> {
+  @override
+  final Iterable<Type> types = const [
+    GGetDeviceInfoData_deviceInfo,
+    _$GGetDeviceInfoData_deviceInfo
+  ];
+  @override
+  final String wireName = 'GGetDeviceInfoData_deviceInfo';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GGetDeviceInfoData_deviceInfo object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'result',
+      serializers.serialize(object.result,
+          specifiedType: const FullType(BuiltList,
+              const [const FullType(GGetDeviceInfoData_deviceInfo_result)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GGetDeviceInfoData_deviceInfoBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'result':
+          result.result.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltList, const [
-                const FullType(GGetDeviceInfoData_acceleratorData)
+                const FullType(GGetDeviceInfoData_deviceInfo_result)
               ]))! as BuiltList<Object?>);
           break;
       }
@@ -68,40 +134,35 @@ class _$GGetDeviceInfoDataSerializer
   }
 }
 
-class _$GGetDeviceInfoData_acceleratorDataSerializer
-    implements StructuredSerializer<GGetDeviceInfoData_acceleratorData> {
+class _$GGetDeviceInfoData_deviceInfo_result__baseSerializer
+    implements
+        StructuredSerializer<GGetDeviceInfoData_deviceInfo_result__base> {
   @override
   final Iterable<Type> types = const [
-    GGetDeviceInfoData_acceleratorData,
-    _$GGetDeviceInfoData_acceleratorData
+    GGetDeviceInfoData_deviceInfo_result__base,
+    _$GGetDeviceInfoData_deviceInfo_result__base
   ];
   @override
-  final String wireName = 'GGetDeviceInfoData_acceleratorData';
+  final String wireName = 'GGetDeviceInfoData_deviceInfo_result__base';
 
   @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GGetDeviceInfoData_acceleratorData object,
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetDeviceInfoData_deviceInfo_result__base object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
-      'refId',
-      serializers.serialize(object.refId, specifiedType: const FullType(int)),
-      'data',
-      serializers.serialize(object.data,
-          specifiedType:
-              const FullType(GGetDeviceInfoData_acceleratorData_data)),
     ];
 
     return result;
   }
 
   @override
-  GGetDeviceInfoData_acceleratorData deserialize(
+  GGetDeviceInfoData_deviceInfo_result__base deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new GGetDeviceInfoData_acceleratorDataBuilder();
+    final result = new GGetDeviceInfoData_deviceInfo_result__baseBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -112,16 +173,6 @@ class _$GGetDeviceInfoData_acceleratorDataSerializer
         case '__typename':
           result.G__typename = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
-          break;
-        case 'refId':
-          result.refId = serializers.deserialize(value,
-              specifiedType: const FullType(int))! as int;
-          break;
-        case 'data':
-          result.data.replace(serializers.deserialize(value,
-                  specifiedType:
-                      const FullType(GGetDeviceInfoData_acceleratorData_data))!
-              as GGetDeviceInfoData_acceleratorData_data);
           break;
       }
     }
@@ -130,48 +181,56 @@ class _$GGetDeviceInfoData_acceleratorDataSerializer
   }
 }
 
-class _$GGetDeviceInfoData_acceleratorData_dataSerializer
-    implements StructuredSerializer<GGetDeviceInfoData_acceleratorData_data> {
+class _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfoSerializer
+    implements
+        StructuredSerializer<
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo> {
   @override
   final Iterable<Type> types = const [
-    GGetDeviceInfoData_acceleratorData_data,
-    _$GGetDeviceInfoData_acceleratorData_data
+    GGetDeviceInfoData_deviceInfo_result__asDeviceInfo,
+    _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo
   ];
   @override
-  final String wireName = 'GGetDeviceInfoData_acceleratorData_data';
+  final String wireName = 'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo';
 
   @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GGetDeviceInfoData_acceleratorData_data object,
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
-      'di',
-      serializers.serialize(object.di, specifiedType: const FullType(int)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
       'description',
       serializers.serialize(object.description,
           specifiedType: const FullType(String)),
     ];
     Object? value;
-    value = object.units;
+    value = object.reading;
     if (value != null) {
       result
-        ..add('units')
+        ..add('reading')
         ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+            specifiedType: const FullType(
+                GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading)));
+    }
+    value = object.setting;
+    if (value != null) {
+      result
+        ..add('setting')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting)));
     }
     return result;
   }
 
   @override
-  GGetDeviceInfoData_acceleratorData_data deserialize(
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new GGetDeviceInfoData_acceleratorData_dataBuilder();
+    final result =
+        new GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -183,21 +242,221 @@ class _$GGetDeviceInfoData_acceleratorData_dataSerializer
           result.G__typename = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
-        case 'di':
-          result.di = serializers.deserialize(value,
-              specifiedType: const FullType(int))! as int;
-          break;
-        case 'name':
-          result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
         case 'description':
           result.description = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
-        case 'units':
-          result.units = serializers.deserialize(value,
+        case 'reading':
+          result.reading.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading))!
+              as GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading);
+          break;
+        case 'setting':
+          result.setting.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting))!
+              as GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingSerializer
+    implements
+        StructuredSerializer<
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading> {
+  @override
+  final Iterable<Type> types = const [
+    GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading,
+    _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading
+  ];
+  @override
+  final String wireName =
+      'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.primaryUnits;
+    if (value != null) {
+      result
+        ..add('primaryUnits')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.commonUnits;
+    if (value != null) {
+      result
+        ..add('commonUnits')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'primaryUnits':
+          result.primaryUnits = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
+          break;
+        case 'commonUnits':
+          result.commonUnits = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingSerializer
+    implements
+        StructuredSerializer<
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting> {
+  @override
+  final Iterable<Type> types = const [
+    GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting,
+    _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting
+  ];
+  @override
+  final String wireName =
+      'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.primaryUnits;
+    if (value != null) {
+      result
+        ..add('primaryUnits')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.commonUnits;
+    if (value != null) {
+      result
+        ..add('commonUnits')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'primaryUnits':
+          result.primaryUnits = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'commonUnits':
+          result.commonUnits = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asErrorReplySerializer
+    implements
+        StructuredSerializer<
+            GGetDeviceInfoData_deviceInfo_result__asErrorReply> {
+  @override
+  final Iterable<Type> types = const [
+    GGetDeviceInfoData_deviceInfo_result__asErrorReply,
+    _$GGetDeviceInfoData_deviceInfo_result__asErrorReply
+  ];
+  @override
+  final String wireName = 'GGetDeviceInfoData_deviceInfo_result__asErrorReply';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetDeviceInfoData_deviceInfo_result__asErrorReply object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asErrorReply deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        new GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -210,19 +469,18 @@ class _$GGetDeviceInfoData extends GGetDeviceInfoData {
   @override
   final String G__typename;
   @override
-  final BuiltList<GGetDeviceInfoData_acceleratorData> acceleratorData;
+  final GGetDeviceInfoData_deviceInfo deviceInfo;
 
   factory _$GGetDeviceInfoData(
           [void Function(GGetDeviceInfoDataBuilder)? updates]) =>
       (new GGetDeviceInfoDataBuilder()..update(updates))._build();
 
-  _$GGetDeviceInfoData._(
-      {required this.G__typename, required this.acceleratorData})
+  _$GGetDeviceInfoData._({required this.G__typename, required this.deviceInfo})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         G__typename, r'GGetDeviceInfoData', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(
-        acceleratorData, r'GGetDeviceInfoData', 'acceleratorData');
+        deviceInfo, r'GGetDeviceInfoData', 'deviceInfo');
   }
 
   @override
@@ -239,14 +497,14 @@ class _$GGetDeviceInfoData extends GGetDeviceInfoData {
     if (identical(other, this)) return true;
     return other is GGetDeviceInfoData &&
         G__typename == other.G__typename &&
-        acceleratorData == other.acceleratorData;
+        deviceInfo == other.deviceInfo;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, G__typename.hashCode);
-    _$hash = $jc(_$hash, acceleratorData.hashCode);
+    _$hash = $jc(_$hash, deviceInfo.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -255,7 +513,7 @@ class _$GGetDeviceInfoData extends GGetDeviceInfoData {
   String toString() {
     return (newBuiltValueToStringHelper(r'GGetDeviceInfoData')
           ..add('G__typename', G__typename)
-          ..add('acceleratorData', acceleratorData))
+          ..add('deviceInfo', deviceInfo))
         .toString();
   }
 }
@@ -268,13 +526,11 @@ class GGetDeviceInfoDataBuilder
   String? get G__typename => _$this._G__typename;
   set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  ListBuilder<GGetDeviceInfoData_acceleratorData>? _acceleratorData;
-  ListBuilder<GGetDeviceInfoData_acceleratorData> get acceleratorData =>
-      _$this._acceleratorData ??=
-          new ListBuilder<GGetDeviceInfoData_acceleratorData>();
-  set acceleratorData(
-          ListBuilder<GGetDeviceInfoData_acceleratorData>? acceleratorData) =>
-      _$this._acceleratorData = acceleratorData;
+  GGetDeviceInfoData_deviceInfoBuilder? _deviceInfo;
+  GGetDeviceInfoData_deviceInfoBuilder get deviceInfo =>
+      _$this._deviceInfo ??= new GGetDeviceInfoData_deviceInfoBuilder();
+  set deviceInfo(GGetDeviceInfoData_deviceInfoBuilder? deviceInfo) =>
+      _$this._deviceInfo = deviceInfo;
 
   GGetDeviceInfoDataBuilder() {
     GGetDeviceInfoData._initializeBuilder(this);
@@ -284,7 +540,7 @@ class GGetDeviceInfoDataBuilder
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
-      _acceleratorData = $v.acceleratorData.toBuilder();
+      _deviceInfo = $v.deviceInfo.toBuilder();
       _$v = null;
     }
     return this;
@@ -311,12 +567,12 @@ class GGetDeviceInfoDataBuilder
           new _$GGetDeviceInfoData._(
               G__typename: BuiltValueNullFieldError.checkNotNull(
                   G__typename, r'GGetDeviceInfoData', 'G__typename'),
-              acceleratorData: acceleratorData.build());
+              deviceInfo: deviceInfo.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'acceleratorData';
-        acceleratorData.build();
+        _$failedField = 'deviceInfo';
+        deviceInfo.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             r'GGetDeviceInfoData', _$failedField, e.toString());
@@ -328,138 +584,121 @@ class GGetDeviceInfoDataBuilder
   }
 }
 
-class _$GGetDeviceInfoData_acceleratorData
-    extends GGetDeviceInfoData_acceleratorData {
+class _$GGetDeviceInfoData_deviceInfo extends GGetDeviceInfoData_deviceInfo {
   @override
   final String G__typename;
   @override
-  final int refId;
-  @override
-  final GGetDeviceInfoData_acceleratorData_data data;
+  final BuiltList<GGetDeviceInfoData_deviceInfo_result> result;
 
-  factory _$GGetDeviceInfoData_acceleratorData(
-          [void Function(GGetDeviceInfoData_acceleratorDataBuilder)?
-              updates]) =>
-      (new GGetDeviceInfoData_acceleratorDataBuilder()..update(updates))
-          ._build();
+  factory _$GGetDeviceInfoData_deviceInfo(
+          [void Function(GGetDeviceInfoData_deviceInfoBuilder)? updates]) =>
+      (new GGetDeviceInfoData_deviceInfoBuilder()..update(updates))._build();
 
-  _$GGetDeviceInfoData_acceleratorData._(
-      {required this.G__typename, required this.refId, required this.data})
+  _$GGetDeviceInfoData_deviceInfo._(
+      {required this.G__typename, required this.result})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
-        G__typename, r'GGetDeviceInfoData_acceleratorData', 'G__typename');
+        G__typename, r'GGetDeviceInfoData_deviceInfo', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(
-        refId, r'GGetDeviceInfoData_acceleratorData', 'refId');
-    BuiltValueNullFieldError.checkNotNull(
-        data, r'GGetDeviceInfoData_acceleratorData', 'data');
+        result, r'GGetDeviceInfoData_deviceInfo', 'result');
   }
 
   @override
-  GGetDeviceInfoData_acceleratorData rebuild(
-          void Function(GGetDeviceInfoData_acceleratorDataBuilder) updates) =>
+  GGetDeviceInfoData_deviceInfo rebuild(
+          void Function(GGetDeviceInfoData_deviceInfoBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GGetDeviceInfoData_acceleratorDataBuilder toBuilder() =>
-      new GGetDeviceInfoData_acceleratorDataBuilder()..replace(this);
+  GGetDeviceInfoData_deviceInfoBuilder toBuilder() =>
+      new GGetDeviceInfoData_deviceInfoBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GGetDeviceInfoData_acceleratorData &&
+    return other is GGetDeviceInfoData_deviceInfo &&
         G__typename == other.G__typename &&
-        refId == other.refId &&
-        data == other.data;
+        result == other.result;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, G__typename.hashCode);
-    _$hash = $jc(_$hash, refId.hashCode);
-    _$hash = $jc(_$hash, data.hashCode);
+    _$hash = $jc(_$hash, result.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'GGetDeviceInfoData_acceleratorData')
+    return (newBuiltValueToStringHelper(r'GGetDeviceInfoData_deviceInfo')
           ..add('G__typename', G__typename)
-          ..add('refId', refId)
-          ..add('data', data))
+          ..add('result', result))
         .toString();
   }
 }
 
-class GGetDeviceInfoData_acceleratorDataBuilder
+class GGetDeviceInfoData_deviceInfoBuilder
     implements
-        Builder<GGetDeviceInfoData_acceleratorData,
-            GGetDeviceInfoData_acceleratorDataBuilder> {
-  _$GGetDeviceInfoData_acceleratorData? _$v;
+        Builder<GGetDeviceInfoData_deviceInfo,
+            GGetDeviceInfoData_deviceInfoBuilder> {
+  _$GGetDeviceInfoData_deviceInfo? _$v;
 
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
   set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  int? _refId;
-  int? get refId => _$this._refId;
-  set refId(int? refId) => _$this._refId = refId;
+  ListBuilder<GGetDeviceInfoData_deviceInfo_result>? _result;
+  ListBuilder<GGetDeviceInfoData_deviceInfo_result> get result =>
+      _$this._result ??=
+          new ListBuilder<GGetDeviceInfoData_deviceInfo_result>();
+  set result(ListBuilder<GGetDeviceInfoData_deviceInfo_result>? result) =>
+      _$this._result = result;
 
-  GGetDeviceInfoData_acceleratorData_dataBuilder? _data;
-  GGetDeviceInfoData_acceleratorData_dataBuilder get data =>
-      _$this._data ??= new GGetDeviceInfoData_acceleratorData_dataBuilder();
-  set data(GGetDeviceInfoData_acceleratorData_dataBuilder? data) =>
-      _$this._data = data;
-
-  GGetDeviceInfoData_acceleratorDataBuilder() {
-    GGetDeviceInfoData_acceleratorData._initializeBuilder(this);
+  GGetDeviceInfoData_deviceInfoBuilder() {
+    GGetDeviceInfoData_deviceInfo._initializeBuilder(this);
   }
 
-  GGetDeviceInfoData_acceleratorDataBuilder get _$this {
+  GGetDeviceInfoData_deviceInfoBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
-      _refId = $v.refId;
-      _data = $v.data.toBuilder();
+      _result = $v.result.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(GGetDeviceInfoData_acceleratorData other) {
+  void replace(GGetDeviceInfoData_deviceInfo other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$GGetDeviceInfoData_acceleratorData;
+    _$v = other as _$GGetDeviceInfoData_deviceInfo;
   }
 
   @override
-  void update(
-      void Function(GGetDeviceInfoData_acceleratorDataBuilder)? updates) {
+  void update(void Function(GGetDeviceInfoData_deviceInfoBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  GGetDeviceInfoData_acceleratorData build() => _build();
+  GGetDeviceInfoData_deviceInfo build() => _build();
 
-  _$GGetDeviceInfoData_acceleratorData _build() {
-    _$GGetDeviceInfoData_acceleratorData _$result;
+  _$GGetDeviceInfoData_deviceInfo _build() {
+    _$GGetDeviceInfoData_deviceInfo _$result;
     try {
       _$result = _$v ??
-          new _$GGetDeviceInfoData_acceleratorData._(
-              G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
-                  r'GGetDeviceInfoData_acceleratorData', 'G__typename'),
-              refId: BuiltValueNullFieldError.checkNotNull(
-                  refId, r'GGetDeviceInfoData_acceleratorData', 'refId'),
-              data: data.build());
+          new _$GGetDeviceInfoData_deviceInfo._(
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, r'GGetDeviceInfoData_deviceInfo', 'G__typename'),
+              result: result.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'data';
-        data.build();
+        _$failedField = 'result';
+        result.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            r'GGetDeviceInfoData_acceleratorData', _$failedField, e.toString());
+            r'GGetDeviceInfoData_deviceInfo', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -468,71 +707,44 @@ class GGetDeviceInfoData_acceleratorDataBuilder
   }
 }
 
-class _$GGetDeviceInfoData_acceleratorData_data
-    extends GGetDeviceInfoData_acceleratorData_data {
+class _$GGetDeviceInfoData_deviceInfo_result__base
+    extends GGetDeviceInfoData_deviceInfo_result__base {
   @override
   final String G__typename;
-  @override
-  final int di;
-  @override
-  final String name;
-  @override
-  final String description;
-  @override
-  final String? units;
 
-  factory _$GGetDeviceInfoData_acceleratorData_data(
-          [void Function(GGetDeviceInfoData_acceleratorData_dataBuilder)?
+  factory _$GGetDeviceInfoData_deviceInfo_result__base(
+          [void Function(GGetDeviceInfoData_deviceInfo_result__baseBuilder)?
               updates]) =>
-      (new GGetDeviceInfoData_acceleratorData_dataBuilder()..update(updates))
+      (new GGetDeviceInfoData_deviceInfo_result__baseBuilder()..update(updates))
           ._build();
 
-  _$GGetDeviceInfoData_acceleratorData_data._(
-      {required this.G__typename,
-      required this.di,
-      required this.name,
-      required this.description,
-      this.units})
+  _$GGetDeviceInfoData_deviceInfo_result__base._({required this.G__typename})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        G__typename, r'GGetDeviceInfoData_acceleratorData_data', 'G__typename');
-    BuiltValueNullFieldError.checkNotNull(
-        di, r'GGetDeviceInfoData_acceleratorData_data', 'di');
-    BuiltValueNullFieldError.checkNotNull(
-        name, r'GGetDeviceInfoData_acceleratorData_data', 'name');
-    BuiltValueNullFieldError.checkNotNull(
-        description, r'GGetDeviceInfoData_acceleratorData_data', 'description');
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        r'GGetDeviceInfoData_deviceInfo_result__base', 'G__typename');
   }
 
   @override
-  GGetDeviceInfoData_acceleratorData_data rebuild(
-          void Function(GGetDeviceInfoData_acceleratorData_dataBuilder)
+  GGetDeviceInfoData_deviceInfo_result__base rebuild(
+          void Function(GGetDeviceInfoData_deviceInfo_result__baseBuilder)
               updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GGetDeviceInfoData_acceleratorData_dataBuilder toBuilder() =>
-      new GGetDeviceInfoData_acceleratorData_dataBuilder()..replace(this);
+  GGetDeviceInfoData_deviceInfo_result__baseBuilder toBuilder() =>
+      new GGetDeviceInfoData_deviceInfo_result__baseBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GGetDeviceInfoData_acceleratorData_data &&
-        G__typename == other.G__typename &&
-        di == other.di &&
-        name == other.name &&
-        description == other.description &&
-        units == other.units;
+    return other is GGetDeviceInfoData_deviceInfo_result__base &&
+        G__typename == other.G__typename;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, G__typename.hashCode);
-    _$hash = $jc(_$hash, di.hashCode);
-    _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, description.hashCode);
-    _$hash = $jc(_$hash, units.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -540,86 +752,628 @@ class _$GGetDeviceInfoData_acceleratorData_data
   @override
   String toString() {
     return (newBuiltValueToStringHelper(
-            r'GGetDeviceInfoData_acceleratorData_data')
-          ..add('G__typename', G__typename)
-          ..add('di', di)
-          ..add('name', name)
-          ..add('description', description)
-          ..add('units', units))
+            r'GGetDeviceInfoData_deviceInfo_result__base')
+          ..add('G__typename', G__typename))
         .toString();
   }
 }
 
-class GGetDeviceInfoData_acceleratorData_dataBuilder
+class GGetDeviceInfoData_deviceInfo_result__baseBuilder
     implements
-        Builder<GGetDeviceInfoData_acceleratorData_data,
-            GGetDeviceInfoData_acceleratorData_dataBuilder> {
-  _$GGetDeviceInfoData_acceleratorData_data? _$v;
+        Builder<GGetDeviceInfoData_deviceInfo_result__base,
+            GGetDeviceInfoData_deviceInfo_result__baseBuilder> {
+  _$GGetDeviceInfoData_deviceInfo_result__base? _$v;
 
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
   set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  int? _di;
-  int? get di => _$this._di;
-  set di(int? di) => _$this._di = di;
-
-  String? _name;
-  String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
-
-  String? _description;
-  String? get description => _$this._description;
-  set description(String? description) => _$this._description = description;
-
-  String? _units;
-  String? get units => _$this._units;
-  set units(String? units) => _$this._units = units;
-
-  GGetDeviceInfoData_acceleratorData_dataBuilder() {
-    GGetDeviceInfoData_acceleratorData_data._initializeBuilder(this);
+  GGetDeviceInfoData_deviceInfo_result__baseBuilder() {
+    GGetDeviceInfoData_deviceInfo_result__base._initializeBuilder(this);
   }
 
-  GGetDeviceInfoData_acceleratorData_dataBuilder get _$this {
+  GGetDeviceInfoData_deviceInfo_result__baseBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
-      _di = $v.di;
-      _name = $v.name;
-      _description = $v.description;
-      _units = $v.units;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(GGetDeviceInfoData_acceleratorData_data other) {
+  void replace(GGetDeviceInfoData_deviceInfo_result__base other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$GGetDeviceInfoData_acceleratorData_data;
+    _$v = other as _$GGetDeviceInfoData_deviceInfo_result__base;
   }
 
   @override
   void update(
-      void Function(GGetDeviceInfoData_acceleratorData_dataBuilder)? updates) {
+      void Function(GGetDeviceInfoData_deviceInfo_result__baseBuilder)?
+          updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  GGetDeviceInfoData_acceleratorData_data build() => _build();
+  GGetDeviceInfoData_deviceInfo_result__base build() => _build();
 
-  _$GGetDeviceInfoData_acceleratorData_data _build() {
+  _$GGetDeviceInfoData_deviceInfo_result__base _build() {
     final _$result = _$v ??
-        new _$GGetDeviceInfoData_acceleratorData_data._(
+        new _$GGetDeviceInfoData_deviceInfo_result__base._(
             G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
-                r'GGetDeviceInfoData_acceleratorData_data', 'G__typename'),
-            di: BuiltValueNullFieldError.checkNotNull(
-                di, r'GGetDeviceInfoData_acceleratorData_data', 'di'),
-            name: BuiltValueNullFieldError.checkNotNull(
-                name, r'GGetDeviceInfoData_acceleratorData_data', 'name'),
-            description: BuiltValueNullFieldError.checkNotNull(description,
-                r'GGetDeviceInfoData_acceleratorData_data', 'description'),
-            units: units);
+                r'GGetDeviceInfoData_deviceInfo_result__base', 'G__typename'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo
+    extends GGetDeviceInfoData_deviceInfo_result__asDeviceInfo {
+  @override
+  final String G__typename;
+  @override
+  final String description;
+  @override
+  final GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading? reading;
+  @override
+  final GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting? setting;
+
+  factory _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo(
+          [void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder)?
+              updates]) =>
+      (new GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo._(
+      {required this.G__typename,
+      required this.description,
+      this.reading,
+      this.setting})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(description,
+        r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo', 'description');
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo rebuild(
+          void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder toBuilder() =>
+      new GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetDeviceInfoData_deviceInfo_result__asDeviceInfo &&
+        G__typename == other.G__typename &&
+        description == other.description &&
+        reading == other.reading &&
+        setting == other.setting;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, reading.hashCode);
+    _$hash = $jc(_$hash, setting.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo')
+          ..add('G__typename', G__typename)
+          ..add('description', description)
+          ..add('reading', reading)
+          ..add('setting', setting))
+        .toString();
+  }
+}
+
+class GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder
+    implements
+        Builder<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo,
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder> {
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder? _reading;
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder
+      get reading => _$this._reading ??=
+          new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder();
+  set reading(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder?
+              reading) =>
+      _$this._reading = reading;
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder? _setting;
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder
+      get setting => _$this._setting ??=
+          new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder();
+  set setting(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder?
+              setting) =>
+      _$this._setting = setting;
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder() {
+    GGetDeviceInfoData_deviceInfo_result__asDeviceInfo._initializeBuilder(this);
+  }
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _description = $v.description;
+      _reading = $v.reading?.toBuilder();
+      _setting = $v.setting?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetDeviceInfoData_deviceInfo_result__asDeviceInfo other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo;
+  }
+
+  @override
+  void update(
+      void Function(GGetDeviceInfoData_deviceInfo_result__asDeviceInfoBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo build() => _build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo _build() {
+    _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo _$result;
+    try {
+      _$result = _$v ??
+          new _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo._(
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename,
+                  r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo',
+                  'G__typename'),
+              description: BuiltValueNullFieldError.checkNotNull(
+                  description,
+                  r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo',
+                  'description'),
+              reading: _reading?.build(),
+              setting: _setting?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'reading';
+        _reading?.build();
+        _$failedField = 'setting';
+        _setting?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading
+    extends GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading {
+  @override
+  final String G__typename;
+  @override
+  final String? primaryUnits;
+  @override
+  final String? commonUnits;
+
+  factory _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading(
+          [void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder)?
+              updates]) =>
+      (new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading._(
+      {required this.G__typename, this.primaryUnits, this.commonUnits})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename,
+        r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading',
+        'G__typename');
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading rebuild(
+          void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder
+      toBuilder() =>
+          new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading &&
+        G__typename == other.G__typename &&
+        primaryUnits == other.primaryUnits &&
+        commonUnits == other.commonUnits;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, primaryUnits.hashCode);
+    _$hash = $jc(_$hash, commonUnits.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading')
+          ..add('G__typename', G__typename)
+          ..add('primaryUnits', primaryUnits)
+          ..add('commonUnits', commonUnits))
+        .toString();
+  }
+}
+
+class GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder
+    implements
+        Builder<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading,
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder> {
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _primaryUnits;
+  String? get primaryUnits => _$this._primaryUnits;
+  set primaryUnits(String? primaryUnits) => _$this._primaryUnits = primaryUnits;
+
+  String? _commonUnits;
+  String? get commonUnits => _$this._commonUnits;
+  set commonUnits(String? commonUnits) => _$this._commonUnits = commonUnits;
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder() {
+    GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading
+        ._initializeBuilder(this);
+  }
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _primaryUnits = $v.primaryUnits;
+      _commonUnits = $v.commonUnits;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_readingBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading build() =>
+      _build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading _build() {
+    final _$result = _$v ??
+        new _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading',
+                'G__typename'),
+            primaryUnits: primaryUnits,
+            commonUnits: commonUnits);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting
+    extends GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting {
+  @override
+  final String G__typename;
+  @override
+  final String? primaryUnits;
+  @override
+  final String? commonUnits;
+
+  factory _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting(
+          [void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder)?
+              updates]) =>
+      (new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting._(
+      {required this.G__typename, this.primaryUnits, this.commonUnits})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename,
+        r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting',
+        'G__typename');
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting rebuild(
+          void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder
+      toBuilder() =>
+          new GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting &&
+        G__typename == other.G__typename &&
+        primaryUnits == other.primaryUnits &&
+        commonUnits == other.commonUnits;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, primaryUnits.hashCode);
+    _$hash = $jc(_$hash, commonUnits.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting')
+          ..add('G__typename', G__typename)
+          ..add('primaryUnits', primaryUnits)
+          ..add('commonUnits', commonUnits))
+        .toString();
+  }
+}
+
+class GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder
+    implements
+        Builder<GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting,
+            GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder> {
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _primaryUnits;
+  String? get primaryUnits => _$this._primaryUnits;
+  set primaryUnits(String? primaryUnits) => _$this._primaryUnits = primaryUnits;
+
+  String? _commonUnits;
+  String? get commonUnits => _$this._commonUnits;
+  set commonUnits(String? commonUnits) => _$this._commonUnits = commonUnits;
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder() {
+    GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting
+        ._initializeBuilder(this);
+  }
+
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _primaryUnits = $v.primaryUnits;
+      _commonUnits = $v.commonUnits;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_settingBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting build() =>
+      _build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting _build() {
+    final _$result = _$v ??
+        new _$GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting',
+                'G__typename'),
+            primaryUnits: primaryUnits,
+            commonUnits: commonUnits);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetDeviceInfoData_deviceInfo_result__asErrorReply
+    extends GGetDeviceInfoData_deviceInfo_result__asErrorReply {
+  @override
+  final String G__typename;
+  @override
+  final String message;
+
+  factory _$GGetDeviceInfoData_deviceInfo_result__asErrorReply(
+          [void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder)?
+              updates]) =>
+      (new GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asErrorReply._(
+      {required this.G__typename, required this.message})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        r'GGetDeviceInfoData_deviceInfo_result__asErrorReply', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(message,
+        r'GGetDeviceInfoData_deviceInfo_result__asErrorReply', 'message');
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asErrorReply rebuild(
+          void Function(
+                  GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder toBuilder() =>
+      new GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetDeviceInfoData_deviceInfo_result__asErrorReply &&
+        G__typename == other.G__typename &&
+        message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetDeviceInfoData_deviceInfo_result__asErrorReply')
+          ..add('G__typename', G__typename)
+          ..add('message', message))
+        .toString();
+  }
+}
+
+class GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder
+    implements
+        Builder<GGetDeviceInfoData_deviceInfo_result__asErrorReply,
+            GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder> {
+  _$GGetDeviceInfoData_deviceInfo_result__asErrorReply? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder() {
+    GGetDeviceInfoData_deviceInfo_result__asErrorReply._initializeBuilder(this);
+  }
+
+  GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _message = $v.message;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetDeviceInfoData_deviceInfo_result__asErrorReply other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GGetDeviceInfoData_deviceInfo_result__asErrorReply;
+  }
+
+  @override
+  void update(
+      void Function(GGetDeviceInfoData_deviceInfo_result__asErrorReplyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetDeviceInfoData_deviceInfo_result__asErrorReply build() => _build();
+
+  _$GGetDeviceInfoData_deviceInfo_result__asErrorReply _build() {
+    final _$result = _$v ??
+        new _$GGetDeviceInfoData_deviceInfo_result__asErrorReply._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GGetDeviceInfoData_deviceInfo_result__asErrorReply',
+                'G__typename'),
+            message: BuiltValueNullFieldError.checkNotNull(
+                message,
+                r'GGetDeviceInfoData_deviceInfo_result__asErrorReply',
+                'message'));
     replace(_$result);
     return _$result;
   }

--- a/lib/gql-dpm/schema/__generated__/serializers.gql.dart
+++ b/lib/gql-dpm/schema/__generated__/serializers.gql.dart
@@ -9,9 +9,14 @@ import 'package:gql_code_builder/src/serializers/operation_serializer.dart'
     show OperationSerializer;
 import 'package:parameter_page/gql-dpm/schema/__generated__/get_device_info.data.gql.dart'
     show
+        GGetDeviceInfoData_deviceInfo_result,
         GGetDeviceInfoData,
-        GGetDeviceInfoData_acceleratorData,
-        GGetDeviceInfoData_acceleratorData_data;
+        GGetDeviceInfoData_deviceInfo,
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo,
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading,
+        GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting,
+        GGetDeviceInfoData_deviceInfo_result__asErrorReply,
+        GGetDeviceInfoData_deviceInfo_result__base;
 import 'package:parameter_page/gql-dpm/schema/__generated__/get_device_info.req.gql.dart'
     show GGetDeviceInfoReq;
 import 'package:parameter_page/gql-dpm/schema/__generated__/get_device_info.var.gql.dart'
@@ -37,12 +42,17 @@ part 'serializers.gql.g.dart';
 final SerializersBuilder _serializersBuilder = _$serializers.toBuilder()
   ..add(OperationSerializer())
   ..add(DateSerializer())
+  ..add(GGetDeviceInfoData_deviceInfo_result.serializer)
   ..add(GStreamDataData_acceleratorData_data_result.serializer)
   ..addPlugin(StandardJsonPlugin());
 @SerializersFor([
   GGetDeviceInfoData,
-  GGetDeviceInfoData_acceleratorData,
-  GGetDeviceInfoData_acceleratorData_data,
+  GGetDeviceInfoData_deviceInfo,
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo,
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading,
+  GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting,
+  GGetDeviceInfoData_deviceInfo_result__asErrorReply,
+  GGetDeviceInfoData_deviceInfo_result__base,
   GGetDeviceInfoReq,
   GGetDeviceInfoVars,
   GStreamDataData,

--- a/lib/gql-dpm/schema/__generated__/serializers.gql.g.dart
+++ b/lib/gql-dpm/schema/__generated__/serializers.gql.g.dart
@@ -9,8 +9,14 @@ part of 'serializers.gql.dart';
 Serializers _$serializers = (new Serializers().toBuilder()
       ..add(FetchPolicy.serializer)
       ..add(GGetDeviceInfoData.serializer)
-      ..add(GGetDeviceInfoData_acceleratorData.serializer)
-      ..add(GGetDeviceInfoData_acceleratorData_data.serializer)
+      ..add(GGetDeviceInfoData_deviceInfo.serializer)
+      ..add(GGetDeviceInfoData_deviceInfo_result__asDeviceInfo.serializer)
+      ..add(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_reading.serializer)
+      ..add(
+          GGetDeviceInfoData_deviceInfo_result__asDeviceInfo_setting.serializer)
+      ..add(GGetDeviceInfoData_deviceInfo_result__asErrorReply.serializer)
+      ..add(GGetDeviceInfoData_deviceInfo_result__base.serializer)
       ..add(GGetDeviceInfoReq.serializer)
       ..add(GGetDeviceInfoVars.serializer)
       ..add(GStreamDataData.serializer)
@@ -24,8 +30,8 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(GStreamDataVars.serializer)
       ..addBuilderFactory(
           const FullType(BuiltList,
-              const [const FullType(GGetDeviceInfoData_acceleratorData)]),
-          () => new ListBuilder<GGetDeviceInfoData_acceleratorData>())
+              const [const FullType(GGetDeviceInfoData_deviceInfo_result)]),
+          () => new ListBuilder<GGetDeviceInfoData_deviceInfo_result>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())

--- a/lib/gql-dpm/schema/get_device_info.graphql
+++ b/lib/gql-dpm/schema/get_device_info.graphql
@@ -1,11 +1,20 @@
 query GetDeviceInfo($names: [String!]!) {
-    acceleratorData(drfs: $names) {
-        refId
-        data {
-            di
-            name
+    deviceInfo(devices: $names) {
+        result {
+          ... on DeviceInfo {
             description
-            units
+            reading {
+              primaryUnits
+              commonUnits
+            }
+            setting {
+              primaryUnits
+              commonUnits
+            }
+          }
+          ... on ErrorReply {
+            message
+          }
         }
     }
 }

--- a/lib/mock-dpm/mock_dpm_service.dart
+++ b/lib/mock-dpm/mock_dpm_service.dart
@@ -7,16 +7,35 @@ class MockDpmService extends DpmService {
 
   @override
   Future<List<DeviceInfo>> getDeviceInfo(List<String> devices) async {
-    return devices
-        .map((drf) => DeviceInfo(
-            di: 0,
-            name: drf,
-            description: "device description",
-            reading: const DeviceInfoProperty(
-                commonUnits: "degF", primaryUnits: "Volt"),
-            setting: const DeviceInfoProperty(
-                commonUnits: "degF", primaryUnits: "Volt")))
-        .toList();
+    return devices.map((drf) {
+      switch (drf) {
+        case "Z:NO_READ":
+          return DeviceInfo(
+              di: 0,
+              name: drf,
+              description: "device description",
+              reading: null,
+              setting: const DeviceInfoProperty(
+                  commonUnits: "cUS", primaryUnits: "pUS"));
+        case "Z:NO_SET":
+          return DeviceInfo(
+              di: 0,
+              name: drf,
+              description: "device description",
+              reading: const DeviceInfoProperty(
+                  commonUnits: "cUR", primaryUnits: "pUR"),
+              setting: null);
+        default:
+          return DeviceInfo(
+              di: 0,
+              name: drf,
+              description: "device description",
+              reading: const DeviceInfoProperty(
+                  commonUnits: "cUR", primaryUnits: "pUR"),
+              setting: const DeviceInfoProperty(
+                  commonUnits: "cUS", primaryUnits: "pUS"));
+      }
+    }).toList();
   }
 
   @override

--- a/lib/widgets/parameter_widget.dart
+++ b/lib/widgets/parameter_widget.dart
@@ -53,8 +53,29 @@ class _ActiveParamWidget extends StatefulWidget {
 class _ActiveParamState extends State<_ActiveParamWidget> {
   late final Future<List<DeviceInfo>> _setup;
   late final Stream<Reading> _stream;
-  String? description;
-  String? units;
+  DeviceInfo? info;
+
+  String? get readingUnits {
+    switch (widget.displayUnits) {
+      case DisplayUnits.commonUnits:
+        return info?.reading?.commonUnits;
+      case DisplayUnits.primaryUnits:
+        return info?.reading?.primaryUnits;
+      case DisplayUnits.raw:
+        return null;
+    }
+  }
+
+  String? get settingUnits {
+    switch (widget.displayUnits) {
+      case DisplayUnits.commonUnits:
+        return info?.setting?.commonUnits;
+      case DisplayUnits.primaryUnits:
+        return info?.setting?.primaryUnits;
+      case DisplayUnits.raw:
+        return null;
+    }
+  }
 
   @override
   void initState() {
@@ -89,12 +110,13 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
                     child: Text(overflow: TextOverflow.ellipsis, widget.drf))),
             Expanded(
                 flex: 2,
-                child:
-                    Text(overflow: TextOverflow.ellipsis, description ?? "")),
+                child: info != null
+                    ? Text(overflow: TextOverflow.ellipsis, info!.description)
+                    : Container()),
             const Spacer(),
             Row(
               children: [
-                _buildParam(_settingValue, _settingUnits,
+                _buildParam(_settingValue, settingUnits,
                     key: Key("parameter_setting_${widget.drf}")),
                 const SizedBox(width: 12.0),
                 StreamBuilder(
@@ -102,10 +124,10 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
                     builder: (context, snapshot) {
                       if (snapshot.connectionState == ConnectionState.active) {
                         return _buildParam(
-                            _extractValueString(from: snapshot), units,
+                            _extractValueString(from: snapshot), readingUnits,
                             key: Key("parameter_reading_${widget.drf}"));
                       } else {
-                        return _buildParam(null, units,
+                        return _buildParam(null, readingUnits,
                             key: Key("parameter_nullreading_${widget.drf}"));
                       }
                     })
@@ -126,23 +148,24 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
           padding: const EdgeInsets.only(left: 8.0),
           child: Text(
               overflow: TextOverflow.ellipsis,
-              description ?? "",
+              info?.description ?? "",
               style: Theme.of(context)
                   .textTheme
                   .bodySmall!
                   .copyWith(fontStyle: FontStyle.italic, color: Colors.grey)),
         ),
         Row(mainAxisAlignment: MainAxisAlignment.spaceAround, children: [
-          _buildParam(_settingValue, units,
+          _buildParam(_settingValue, settingUnits,
               key: Key("parameter_setting_${widget.drf}")),
           StreamBuilder(
               stream: _stream,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.active) {
-                  return _buildParam(_extractValueString(from: snapshot), units,
+                  return _buildParam(
+                      _extractValueString(from: snapshot), readingUnits,
                       key: Key("parameter_reading_${widget.drf}"));
                 } else {
-                  return _buildParam(null, units,
+                  return _buildParam(null, readingUnits,
                       key: Key("parameter_nullreading_${widget.drf}"));
                 }
               })
@@ -159,9 +182,6 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
         return from.data!.primaryValue.toStringAsPrecision(4);
       case DisplayUnits.raw:
         return from.data!.rawValue;
-      default:
-        AssertionError("Invalid displayUnits!");
-        return "Invalid displayUnits!";
     }
   }
 
@@ -169,13 +189,11 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      // The FUtureBuilder monitors our `getDeviceInfo` query. When it
-      // completes, we transfer over the values of `description` and `units` so
-      // the widgets can display them.
+      // The FutureBuilder monitors our `getDeviceInfo` query. When it
+      // completes, we save the information.
 
       future: _setup.then((value) {
-        description = value.first.description;
-        units = _extractReadingUnits(from: value);
+        info = value.first;
         return value;
       }),
 
@@ -187,34 +205,6 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
     );
   }
 
-  String _extractReadingUnits({required from}) {
-    switch (widget.displayUnits) {
-      case DisplayUnits.commonUnits:
-        return from.first.reading.commonUnits;
-      case DisplayUnits.primaryUnits:
-        return from.first.reading.primaryUnits;
-      case DisplayUnits.raw:
-        return "";
-      default:
-        AssertionError("Invalid displayUnits!");
-        return "Invalid displayUnits!";
-    }
-  }
-
-  String get _settingUnits {
-    switch (widget.displayUnits) {
-      case DisplayUnits.commonUnits:
-        return "mm";
-      case DisplayUnits.primaryUnits:
-        return "Volt";
-      case DisplayUnits.raw:
-        return "";
-      default:
-        AssertionError("Invalid displayUnits!");
-        return "Invalid displayUnits!";
-    }
-  }
-
   String get _settingValue {
     switch (widget.displayUnits) {
       case DisplayUnits.commonUnits:
@@ -223,9 +213,6 @@ class _ActiveParamState extends State<_ActiveParamWidget> {
         return "5.0";
       case DisplayUnits.raw:
         return "8888";
-      default:
-        AssertionError("Invalid displayUnits!");
-        return "Invalid displayUnits!";
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "98d1d33ed129b372846e862de23a0fc365745f4d7b5e786ce667fcbbb7ac5c07"
+      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
       url: "https://pub.dev"
     source: hosted
-    version: "55.0.0"
+    version: "61.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "881348aed9b0b425882c97732629a6a31093c8ff20fc4b3b03fb9d3d50a3a126"
+      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.1"
+    version: "5.13.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   async:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   build_config:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "757153e5d9cd88253cb13f28c2fb55a537dc31fefd98137549895b5beb7c6169"
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -77,18 +77,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      sha256: "220ae4553e50d7c21a17c051afc7b183d28a24a420502e842f303f8e4e6edced"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      sha256: "88a57f2ac99849362e73878334caa9f06ee25f31d2adced882b8337838c84e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.7"
+    version: "7.2.9"
   built_collection:
     dependency: "direct main"
     description:
@@ -101,18 +101,18 @@ packages:
     dependency: "direct main"
     description:
       name: built_value
-      sha256: "31b7c748fd4b9adf8d25d72a4c4a59ef119f12876cf414f94f8af5131d5fa2b0"
+      sha256: "7dd62d9faf105c434f3d829bbe9c4be02ec67f5ed94832222116122df67c5452"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.4"
+    version: "8.6.0"
   built_value_generator:
     dependency: transitive
     description:
       name: built_value_generator
-      sha256: "6c7d31060667a309889e45fd86fcaec6477750d767cf32a7f7ce4b1578d3440c"
+      sha256: de8657db23599dfb104a66fca02a45a55bb62a3b27c4e637c91610783896263c
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.4"
+    version: "8.6.0"
   characters:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
+      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   fake_async:
     dependency: transitive
     description:
@@ -205,50 +205,50 @@ packages:
     dependency: "direct main"
     description:
       name: ferry
-      sha256: a04d49b526fc92d5af2599509b9d4b0e449f67a1b354718087e77b1bc1956e08
+      sha256: "712f94fb2a4b996e05db2afd4d26f0eb2c7c1f6b40af43dc49f5e418b34916a5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.0+1"
+    version: "0.14.2+1"
   ferry_cache:
     dependency: transitive
     description:
       name: ferry_cache
-      sha256: "1df2f86924fbff8635d99e5bf2993297e8463d382905bd49ecf3be8869f9c17a"
+      sha256: "6d0afa3d2451d1c57c7894254c60cb683c8a8be5598a2ba97c48837f1deb3254"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1+1"
+    version: "0.7.1+2"
   ferry_exec:
     dependency: transitive
     description:
       name: ferry_exec
-      sha256: "770acb85a259936b362e1ae3fa4f10cd43fe13628d590fefa12154400f6122ce"
+      sha256: "2da33c4b4396d9874af5af37cc72692dbcd2194310871c77381f08b5327cec9d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.1"
   ferry_flutter:
     dependency: "direct main"
     description:
       name: ferry_flutter
-      sha256: c4483cd33068131773f157224c484e96a3db9dd969d45d56a454ba56834e6569
+      sha256: "57c0f441bda868107dfdd7c18491286bbb3b3e5cf6c668f175bde7379b62a537"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0+1"
+    version: "0.8.1"
   ferry_generator:
     dependency: "direct dev"
     description:
       name: ferry_generator
-      sha256: "45afa3b1482ac8dde331f80d8d55ba26ad04de1accbd7fd88738abd415d6abfb"
+      sha256: dc744553cb9f969c9a784246b3a238f72b4058dce829cb3b4bd6fcf2713cf12f
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0+1"
+    version: "0.8.1"
   ferry_store:
     dependency: transitive
     description:
       name: ferry_store
-      sha256: "6acf2327d40dfe189976d2a8ad92687168d0b2a7dc30c8b0f902ee23b04c2422"
+      sha256: f1180951756583750c996e085d80dd14e77d0750e3b6b232b495bf92bd1f425b
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.3"
   file:
     dependency: transitive
     description:
@@ -305,66 +305,66 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   gql:
     dependency: transitive
     description:
       name: gql
-      sha256: "998304fbb88a3956cfea10cd27a56f8e5d4b3bc110f03c952c18a9310774e8bb"
+      sha256: b05d544d709d276c0cced82d630518e92139b426b20d1b11e973e123d07fbf52
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.0"
+    version: "1.0.0"
   gql_code_builder:
     dependency: transitive
     description:
       name: gql_code_builder
-      sha256: "66fc942416d9703e59ac732b2cb4e8442261fc90e1fcf89881b5b796d0803d02"
+      sha256: "6e386a85f5d91daae82915337f566a43dfeb0a0df38caa372387fbc07d31b8c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   gql_exec:
     dependency: transitive
     description:
       name: gql_exec
-      sha256: "0d1fdb2e4154efbfc1dcf3f35ec36d19c8428ff0d560eb4c45b354f8f871dc50"
+      sha256: "50bcdb389e25411dce84cca8af50d9277492fc55d6358fa2ec2039e58b8fe22d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "1.0.0"
   gql_http_link:
     dependency: "direct main"
     description:
       name: gql_http_link
-      sha256: "89ef87b32947acf4189f564c095f1148b0ab9bb9996fe518716dbad66708b834"
+      sha256: "365c0e72da7e29e007c4a0ed7a470f6c03af1ef00acd2af3c22157c8bb47f314"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.5"
+    version: "1.0.0"
   gql_link:
     dependency: transitive
     description:
       name: gql_link
-      sha256: f7973279126bc922d465c4f4da6ed93d187085e597b3480f5e14e74d28fe14bd
+      sha256: c09b7a5797bdb9acb946083072d223c16658fd7b3ac4ff91b9d5a83c30ee8cf2
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.0.0"
   gql_websocket_link:
     dependency: "direct main"
     description:
       name: gql_websocket_link
-      sha256: bb325ff05e16815c45600a5b56843a7f64fc04bb6a9690920fade70fc8080b0b
+      sha256: b2cb66da34ff01ae5f31809ff37e583a4360d2b8f1e7139c0f426caf291284fc
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4+1"
+    version: "1.0.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   hive:
     dependency: transitive
     description:
@@ -377,10 +377,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
@@ -422,26 +422,26 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "6b0206b0bf4f04961fc5438198ccb3a885685cd67d4d4a32cc20ad7f8adbe015"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
@@ -486,10 +486,10 @@ packages:
     dependency: transitive
     description:
       name: normalize
-      sha256: "31a6742a7d702a0dc6f66536bf6749af85fae51ffcd77bf27de1e5c01b314c12"
+      sha256: "8a60e37de5b608eeaf9b839273370c71ebba445e9f73b08eee7725e0d92dbc43"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0+1"
+    version: "0.8.2+1"
   package_config:
     dependency: transitive
     description:
@@ -542,18 +542,18 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   rxdart:
     dependency: transitive
     description:
@@ -574,34 +574,34 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -611,10 +611,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: c2bea18c95cfa0276a366270afaa2850b09b4a76db95d546f3d003dcc7011298
+      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.7"
+    version: "1.3.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -723,10 +723,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   uuid:
     dependency: transitive
     description:
@@ -755,18 +755,18 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   webdriver:
     dependency: transitive
     description:
@@ -787,9 +787,9 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0
 
 environment:
-    sdk: ">=2.19.0-146.2.beta <3.0.0"
+    sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -39,8 +39,8 @@ dependencies:
     cupertino_icons: ^1.0.2
     ferry: ^0.14.0+1
     ferry_flutter: ^0.8.0+1
-    gql_http_link: ^0.4.5
-    gql_websocket_link: ^0.3.4+1
+    gql_http_link: ^1.0.0
+    gql_websocket_link: ^1.0.0
     built_collection: ^5.1.1
     built_value: ^8.4.4
     settings_ui: ^2.0.2

--- a/test/integration_tests/change_display_units_test.dart
+++ b/test/integration_tests/change_display_units_test.dart
@@ -19,9 +19,9 @@ void main() {
       // Then M:OUTTMP should show units of degF
       assertParameterHasDetails("M:OUTTMP@e,02",
           settingValue: "50.0",
-          settingUnits: "mm",
+          settingUnits: "cUS",
           readingValue: "100.0",
-          readingUnits: "degF");
+          readingUnits: "cUR");
     });
 
     testWidgets('Initially, Display Settings > Units is set to Common Units',
@@ -53,9 +53,9 @@ void main() {
       // Then the M:OUTTMP units change to Volts
       assertParameterHasDetails("M:OUTTMP@e,02",
           settingValue: "5.0",
-          settingUnits: "Volt",
+          settingUnits: "pUS",
           readingValue: "10.00",
-          readingUnits: "Volt");
+          readingUnits: "pUR");
     });
 
     testWidgets(
@@ -89,10 +89,7 @@ void main() {
 
       // Then no units are display for M:OUTTMP
       assertParameterHasDetails("M:OUTTMP@e,02",
-          settingValue: "8888",
-          settingUnits: "",
-          readingUnits: "",
-          readingValue: "FFFF");
+          settingValue: "8888", readingValue: "FFFF");
     });
   });
 }


### PR DESCRIPTION
The `deviceInfo` query is now using the DevDB gRPC service. This PR contains the necessary changes. NOTE: we still need to extract the device name from the DRF string when using this query. This PR doesn't provide this feature, so only rows with device names work (i.e. G:AMANDA).

TO DO:

- [ ] Pull the device name from the DRF string, when using this query.
- [ ] Use the `DeviceInfo` reply to determine if the device has readings and settings (instead of assuming it has both.)
- [ ] Use the above information to create DEVICE.READING and DEVICE.SETTING requests

I don't know whether we want to keep this pull request open to add these features or open new issues to track them. I think I'd prefer the latter.