### PR TITLE
Comment out `base` to use default state.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,15 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+  <!-- 
+    Using this doesn't allow for the default state, `location.href` documented
+    in the link above to work. This resource,
+    https://github.com/flutter/flutter/issues/69760 suggests commenting out
+    the base tag as a way to use the default state. This is a source file that
+    is used to generate the index.html file that is used by the web app. The
+    base tag is commented out in the generated index.html file.
+    <base href="$FLUTTER_BASE_HREF">
+  -->
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
The default base href is `location.href`. Commenting out the `base` in the index.html file is how we got the default behavior. This issue discusses this https://github.com/flutter/flutter/issues/69760.