### PR TITLE
CICD: Cancel in progress in-progress jobs or runs for the current wor…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - "main"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
…kflow

This will help to cancel duplicated runs when a PR does a rebase